### PR TITLE
Fix humphd/brackets#193 - Hide the attached live preview window when the detached live preview is opened

### DIFF
--- a/lib/UI.js
+++ b/lib/UI.js
@@ -102,7 +102,20 @@ define(function (require, exports, module) {
                                "Click to open preview in separate window", "status-overwrite");
 
         $("#liveDevButton").click(function () {
-            IframeBrowser.detachPreview();
+            Resizer.makeResizable("#second-pane");
+
+            // Checks if the attached preview is visible.
+            // If it is, the attached preview is hidden
+            // and the detached preview is opened.
+            if(Resizer.isVisible("#second-pane")) {
+                Resizer.hide("#second-pane");
+                $("#first-pane").addClass("expandEditor");
+                IframeBrowser.detachPreview();
+            }
+            else {
+                Resizer.show("#second-pane");
+                $("#first-pane").removeClass("expandEditor");
+            }
         });
     }
 

--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -5,3 +5,7 @@
 	background-size: contain;
 	display: block;
 }
+
+.expandEditor {
+	width: 100% !important;
+}


### PR DESCRIPTION
Fixes https://github.com/humphd/brackets/issues/193. When the live preview button is pressed the attached preview width is set to 0 and the editor pane width is set to 100%.
